### PR TITLE
Update Dockerfile with fix-permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,5 @@ ENV CONDA_DEFAULT_ENV ${conda_env}
 
 COPY data /home/$NB_USER/work/data
 COPY python /home/$NB_USER/work/python
+
+RUN fix-permissions /home/$NB_USER


### PR DESCRIPTION
added fix-permissions at the end after copy tasks to prevent notebook running read-only