### PR TITLE
Intro Forecasting Notebooks R version (#51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,11 @@ dmypy.json
 
 #vscode
 .vscode
+
+# RStudio
 .Rproj.user
+.RData
+.Rhistory
+.Rapp.history
+.Renviron
+*.nb.html

--- a/R/intro_forecasting/basel_stl_forecasting.rmd
+++ b/R/intro_forecasting/basel_stl_forecasting.rmd
@@ -1,0 +1,125 @@
+---
+title: "Introduction to STL Forecasting"
+output: html_notebook
+---
+
+In this notebook we present a [decomposition model](https://fabletools.tidyverts.org/reference/decomposition_model.html) that combines STL (Seasonal and Trend decomposition using Loess) and ETS/ARIMA with [tidyverts](https://tidyverts.org/). From the documentation:
+
+> This function allows you to specify a decomposition combination model using any additive decomposition. It works by first decomposing the data using the decomposition method provided to dcmp_fn with the given formula. Secondary models are used to fit each of the components from the resulting decomposition.
+
+For more details see Forecasting: [Principles and Practice, Section 3.6 STL Decomposition](https://otexts.com/fpp3/stl.html).
+
+```{r}
+library(readr)
+library(dplyr)
+library(lubridate)
+library(ggplot2)
+library(fable)
+library(feasts)
+library(stringr)
+options(dplyr.summarise.inform=F) 
+```
+
+# Read Data
+
+We will use the Basel temperature data set.
+
+```{r}
+raw_df <- read_csv('../../data/basel_weather.csv')
+```
+
+# EDA
+
+```{r}
+data_df <- raw_df %>%
+  rename(temperature    = `Basel Temperature [2 m elevation corrected]`,
+         precipitation  = `Basel Precipitation Total`,
+         wind_speed     = `Basel Wind Speed [10 m]`,
+         wind_direction = `Basel Wind Direction [10 m]`) %>%
+  mutate(date      = date(timestamp),
+         year      = year(timestamp),
+         month     = month(timestamp),
+         day       = day(timestamp),
+         dayofyear = yday(timestamp),
+         hour      = hour(timestamp))
+
+daily_data_df <- data_df %>%
+  group_by(date, year, month, day, dayofyear) %>%
+  summarise(temperature = mean(temperature)) %>%
+  as_tsibble(index=date)
+
+daily_data_df %>% head()
+```
+
+```{r}
+autoplot(daily_data_df, temperature) +
+  labs(title='Basel Temperature (Daily)', y=expression(degree*C))
+```
+The time series contains a strong seasonal component.
+
+```{r}
+daily_data_df %>% gg_season(temperature)
+```
+We check the decomposition of the time series using STL.
+
+```{r}
+daily_data_df %>% 
+  model(STL(temperature ~ season(period = 365, window = Inf))) %>% 
+  components() %>% 
+  autoplot()
+```
+
+# Train-Test Split
+
+```{r}
+train_test_cut_date <- as_date('2019-01-01')
+
+df_train <- daily_data_df %>% filter(date < train_test_cut_date)
+df_test <- daily_data_df %>% filter(date >= train_test_cut_date)
+
+daily_data_df %>%
+  mutate(data_set = if_else(date < train_test_cut_date, 'train', 'test')) %>%
+  ggplot(aes(x=date, y=temperature, color=data_set)) +
+  geom_line() +
+  labs(title='Basel Temperature (Daily)', y=expression(degree*C)) +
+  geom_vline(xintercept = train_test_cut_date, linetype = "longdash")
+```
+# Model Fit
+
+We fit an exponential smoothing and an ARIMA model to the seasonal adjusted time series.
+
+```{r}
+fit <- df_train %>%
+  model(
+    stl_arima = decomposition_model(
+      STL(temperature ~ season(period = 365, window = Inf)),
+      ARIMA(season_adjust ~ 0 + pdq(2, 1, 1) + PDQ(0, 0, 0))
+    ),
+    stl_ets =  decomposition_model(
+      STL(temperature ~ season(period = 365, window = Inf)),
+      ETS(season_adjust ~ season("N"))
+    )
+  )
+```
+
+# Generate Forecast
+
+```{r}
+fc <- fit %>%
+  forecast(h = nrow(df_test))
+```
+
+```{r}
+error <- fc %>% accuracy(df_test)
+
+rmse_arima <- error %>% filter(.model=="stl_arima") %>% pull(RMSE)
+rmse_ets <- error %>% filter(.model=="stl_ets") %>% pull(RMSE)
+```
+
+```{r}
+fc %>% autoplot(df_test, level=c()) +
+  labs(title='Basel Temperature (Daily)', y=expression(degree*C)) +
+  scale_color_discrete(labels = c(stl_arima = str_interp("STL+ARIMA rmse = $[.2f]{rmse_arima}"),
+                                  stl_ets = str_interp("STL+ETS rmse = $[.2f]{rmse_ets}")))
+```
+

--- a/R/intro_forecasting/intro_arima.rmd
+++ b/R/intro_forecasting/intro_arima.rmd
@@ -1,0 +1,177 @@
+---
+title: "Auto-regressive integrated moving average models"
+output: html_notebook
+---
+
+```{r}
+library(dplyr)
+library(lubridate)
+library(tidyr)
+library(climate)
+library(fable)
+library(feasts)
+library(tsibble)
+library(rsample)
+options(dplyr.summarise.inform=F) 
+```
+
+
+# Introduction
+
+ARIMA stands for Auto-Regressive Integrated Moving Average. Let's go through each one of these concepts one by one.
+
+## Auto-regressive
+
+$$y_t = c + \rho_1 y_{t-1} + \rho_2 y_{t-2} + e_t$$
+
+The autoregressive part of the model assumes that the best way to explain the current value in a time series is using a set number of the past observations. In this case, we are looking at a AR(2) model, and $\rho_1$ and $\rho_2$ are the parameters of interest for the model.
+
+## Moving average
+
+The moving average component assumes that the best explanation for a time series is the error term of the previous values in the series:
+
+$$y_t = c + \mu_1 e_{t-1} + \mu_1 e_{t-2} + e_t$$
+
+This would be a MA(2) model, and $\mu_1$ and $\mu_2$ are the parameters of interest of the model.
+
+## Integrated
+
+This value determines the amount of times we differentiate the series ($y_t-y_{t-1}$) for the AR and MA models above.
+
+The final equation depends on the integrated term. For more information on the functional form of the seasonal ARIMA, please check the fable documentation.
+
+The parameters we are going to use below are $p$ for the AR component, $d$ for the integrated component, and $q$ for the MA component.
+
+# Data processing
+
+For this tutorial we are going to use the CO2 data available in the climate package.
+
+```{r}
+data <- climate::meteo_noaa_co2() %>% select(yy, mm, co2_avg) %>% filter(yy < 2003)
+data %>% head(25)
+```
+We would like to reorganize the data set in monthly data.
+
+```{r}
+y <- data %>%
+  group_by(year_month = yearmonth(ISOdate(yy, mm, 1))) %>%
+  summarize(co2 = mean(co2_avg)) %>%
+  as_tsibble()
+```
+There are no missing months, but if there were, we would fill them like this...
+
+```{r}
+y <- y %>%
+  fill_gaps() %>%
+  fill(co2)
+```
+
+```{r}
+autoplot(y)
+```
+```{r}
+y %>%
+  features(co2, unitroot_kpss)
+```
+```{r}
+y %>%
+  mutate(diff_co2 = difference(co2)) %>% 
+  features(diff_co2, unitroot_kpss)
+```
+```{r}
+y %>%
+  mutate(diff_co2 = difference(co2)) %>%
+  autoplot(diff_co2)
+```
+# Grid search
+
+Since we have little information about the data generating process that generates the data we are going to study, we can use a grid search to determine the set of parameters that best explains the data using a simple metric: the Akaike Information Criteria.
+
+The AIC is a tool we use to measure the performance of a model. By itself it does not really provide much information, but it shines when it is used to compare two or more models.
+
+```{r}
+y %>%
+  model(ARIMA(co2 ~ 0 + pdq(0, 1, 1) + PDQ(0, 0, 0))) %>%
+  report()
+```
+
+```{r}
+y %>%
+  mutate(diff_co2 = difference(co2)) %>%
+  model(ARIMA(diff_co2 ~ 0 + pdq(0, 0, 1) + PDQ(0, 0, 0))) %>%
+  report()
+```
+```{r}
+y %>%
+  model(ARIMA(co2 ~ 0 + pdq(0:2, 0:2, 0:2) + PDQ(0, 0, 0), ic="aic")) %>%
+  report()
+```
+
+According to this calculation, ARIMA(2,1,1) is the best performing model in terms of AIC out of the set of possible parameters analyzed.
+
+```{r}
+y %>%
+  model(ARIMA(co2 ~ 0 + pdq(2, 1, 1) + PDQ(0, 0, 0))) %>%
+  coef()
+```
+
+```{r}
+split <- initial_time_split(y, 0.9)
+
+fit <- training(split) %>%
+  model(ARIMA(co2 ~ 0 + pdq(2, 1, 1) + PDQ(0, 0, 0)))
+
+fc <- fit %>%
+  forecast(h = nrow(testing(split)))
+```
+
+```{r}
+fc %>% accuracy(testing(split))
+```
+```{r}
+fc %>% autoplot(testing(split))
+```
+The forecast is not great, primarily because our model does not take into consideration the clearly seasonal model of the data.
+
+We can expand this experiment by allowing a seasonal component to be added to the modeling. With long and clearly seasonal data sets like this one, it might generate better results.
+
+# Seasonal ARIMA
+
+We can include a seasonal component to the estimation of the time series to incorporate the typical monthly behavior not included in traditional ARIMA analysis.
+
+
+```{r}
+y %>%
+  model(ARIMA(co2 ~ 0 + pdq(0:2, 0:2, 0:2) + PDQ(0:1, 0:1, 0:1), ic="aic")) %>%
+  report()
+```
+```{r}
+y %>%
+  model(ARIMA(co2 ~ 0 + pdq(0, 1, 1) + PDQ(1, 1, 1))) %>%
+  coef()
+```
+
+```{r}
+fit <- training(split) %>%
+  model(ARIMA(co2 ~ 0 + pdq(0, 1, 1) + PDQ(1, 1, 1)))
+
+fc <- fit %>%
+  forecast(h = nrow(testing(split)))
+```
+
+```{r}
+fc %>% accuracy(testing(split))
+```
+
+```{r}
+fc %>% autoplot(testing(split))
+```
+# Some notes
+
+* This notebook tries to mimic the python version, however there are some differences.
+  * in theory the data set is the same (CO2 Mauna Loa (NOAA)), but in practice it is a bit different
+  * this notebook uses the KPSS test instead of the ADF test.
+  * the optimal seasonal ARIMA in this notebook has a non-seasonal component that is not auto-regressive ($p=0$).
+* We determined the best model using the AIC. There are other target functions you can use to choose your $p$, $d$, and $q$ parameters. One possibility is the mean square error between the predicted values given a set of parameters, and the test set.
+* An alternative way to check whether we have the right set of parameters is to check the ACF of the errors.
+* We must not forget to check whether the chosen parameters to explain our model fit our understanding of the underlying data.

--- a/R/intro_forecasting/intro_exponential_smoothing.Rmd
+++ b/R/intro_forecasting/intro_exponential_smoothing.Rmd
@@ -1,0 +1,152 @@
+---
+title: "Introduction To Exponential Smoothing"
+output: html_notebook
+---
+
+Loading packages and set up the notebook.
+
+```{r}
+library(readr)
+library(dplyr)
+library(tibble)
+library(ggplot2)
+library(fable)
+```
+
+Load sample data (prepared earlier).
+
+```{r}
+df <- read_csv("../../data/intro_ets.csv") %>%
+  rowid_to_column("id") %>%
+  as_tsibble(index=id)
+df %>% head()
+```
+
+# Simple Exponential Smoothing
+
+Formula for simple exponential smoothing...
+
+\begin{align}
+s_t &= \alpha x_t + (1-\alpha) s_{t-1} \\
+    &= \alpha x_t + (1-\alpha)(\alpha x_{t-1} + (1-\alpha) s_{t-2}) \\
+    &= \alpha x_t + (1-\alpha) \alpha x_{t-1} + (1-\alpha)^2 s_{t-2}
+\end{align}
+
+Lets now try out simple exponential smoothing on a time series
+
+```{r}
+df %>% autoplot(t1)
+```
+Train the model with arbitrary smoothing_level (alpha) parameter:
+
+```{r}
+fit <- df %>%
+  model(
+    ETS(t1 ~ trend("N", alpha=0.2) + season("N"))
+  )
+```
+
+The plot below shows the original time series and the backfit exponential smoothing values. Adjusting the alpha parameter controls the smoothness. Values of alpha near 1 put larger weights on more recent values. Values of alpha near 0 put larger weights on older values and hence we get a smoother fit.
+
+```{r}
+fit %>%
+  augment() %>%
+  pivot_longer(c(t1, .fitted)) %>%
+  ggplot(aes(x=id, y=value, colour=name)) +
+  geom_line()
+```
+Now lets look at the forecast:
+
+```{r}
+fit %>%
+  forecast(h=20) %>%
+  autoplot(df)
+```
+What happens when we try it on a a series with a trend?
+
+```{r}
+df %>% autoplot(t2)
+```
+```{r}
+df %>%
+  model(
+    ETS(t2 ~ trend("N", alpha=0.2) + season("N"))
+  ) %>%
+  forecast(h=20) %>%
+  autoplot(df)
+```
+# Double Exponential Smoothing
+
+\begin{align}
+s_t &= \alpha x_t + (1-\alpha)(s_{t-1} + b_{t-1}) \\
+b_t &= \beta (s_t-s_{t-1}) + (1-\beta) b_{t-1}
+\end{align}
+
+```{r}
+df %>%
+  model(
+    ETS(t2 ~ trend("A", alpha=0.5, beta=0.5) + season("N"))
+  ) %>%
+  forecast(h=20) %>%
+  autoplot(df)
+```
+Ok, that works on simple series, but what if we want to exploit a known seasonal pattern?
+
+```{r}
+df %>% autoplot(t3)
+```
+# Triple Exponential Smoothing
+
+Add in a another formula to account for periodic cycles!
+
+Triple Exponential Smoothing (Additive)
+
+\begin{align}
+s_0 &= x_0 \\
+s_t &= \alpha(x_t - c_{t-L})+(1-\alpha)(s_{t-1}+b_{t-1}) \\
+b_t &= \beta(s_t - s_{t-1}) + (1-\beta)b_{t-1} \\
+c_t &= \gamma(x_t - s_{t-1} - b_{t-1}) + (1 - \gamma)c_{t-L} \\
+F_{t+m} &= s_t + mb_t + c_{t-L+1+(m-1) \bmod L} \\
+\end{align}
+
+```{r}
+df %>%
+  model(
+    ETS(t3 ~ trend("A", alpha=0.4, beta=0.01) + season("A", period=20, gamma=0.2))
+  ) %>%
+  forecast(h=20) %>%
+  autoplot(df)
+```
+# Exponential Growth
+
+```{r}
+df %>% autoplot(t4)
+```
+```{r}
+df %>%
+  model(
+    ETS(t4 ~ trend("M", alpha=0.6, beta=0.5) + season("N"))
+  ) %>%
+  forecast(h=20, times=100) %>%
+  autoplot(df)
+```
+# Choosing alpha, beta, gamma automatically
+
+The fable package can find the best parameters of alpha, beta and gamma via backfitting. Once you have chosen the appropriate model above, then this a great option to get a baseline.
+
+```{r}
+fit <- df %>%
+  model(
+    ETS(t3 ~ trend("A") + season("A", period=20))
+  )
+fit %>% coef()
+```
+
+```{r}
+fit %>%
+  forecast(h=20) %>%
+  autoplot(df)
+```
+ 
+ 
+ 


### PR DESCRIPTION
Created a first version for the STL forecasting notebook using tidyverts. It's close to the original:

- introduction contains a quote from tidyverts instead of statsmodels
- date time components (year, month, ...) are created although they are not used following the original
- includes two plots (seasonal and STL decomposition) that are not present in the statsmodels/python version
- fabletools::decomposition_model is the closest fit to the STLforecast from statsmodels
- uses RMSE instead of MSE as MSE is not included in the default fabletools::accuracy

The ARIMA notebook is also close to the original:

- in the python version the data is from the statsmodels packages - the climate package (R) contains (almost) the same data
- uses the KPSS test for unit root instead of the ADF
- grid search is done by the fable package
- the optimal seasonal ARIMA in R has a non-seasonal component that is not auto-regressive (p=0) compared with the python version (p=1)

The  ETS notebook is also close to the original:

- did not include the picture for the simple exponential smoothing
- some fixed parameters are set differently because the R implementation would not fit otherwise (however, this makes little difference)